### PR TITLE
use Current Layout for keyboard (added native API call)

### DIFF
--- a/Sample/MainWindow.xaml.cs
+++ b/Sample/MainWindow.xaml.cs
@@ -13,7 +13,8 @@ namespace Sample
             InitializeComponent();
             VirtualKeyboard.OnScreenKeyControlBuilder = new SampleKeyControlBuilder();
             VirtualKeyboard.DataContext = new KPDOnScreenKeyboardViewModel();
-            ((KPDOnScreenKeyboardViewModel)VirtualKeyboard.DataContext).Refresh(KeyboardHelper.InstalledKeyboardLayouts["US"], new ModiferStateManager());
+            var handle = ((NativeMethods.GetKeyboardLayout(0).ToInt32() >> 16) & 0xFFFF).ToString("x8");
+            ((KPDOnScreenKeyboardViewModel)VirtualKeyboard.DataContext).Refresh(KeyboardHelper.InstalledKeyboardLayouts[handle], new ModiferStateManager());
         }
     }
 }

--- a/Sample/PopupKeyboard.xaml.cs
+++ b/Sample/PopupKeyboard.xaml.cs
@@ -30,7 +30,8 @@ namespace Sample
             InitializeComponent();
             VirtualKeyboard.OnScreenKeyControlBuilder = new SampleKeyControlBuilder();
             VirtualKeyboard.DataContext = new KPDOnScreenKeyboardViewModel();
-            ((KPDOnScreenKeyboardViewModel)VirtualKeyboard.DataContext).Refresh(KeyboardHelper.InstalledKeyboardLayouts["US"], new ModiferStateManager());
+            var handle = ((NativeMethods.GetKeyboardLayout(0).ToInt32() >> 16) & 0xFFFF).ToString("x8");
+            ((KPDOnScreenKeyboardViewModel)VirtualKeyboard.DataContext).Refresh(KeyboardHelper.InstalledKeyboardLayouts[handle], new ModiferStateManager());
         }
     }
 }

--- a/WPFKeyboard.KBD.Tests/ToUnicodeTests.cs
+++ b/WPFKeyboard.KBD.Tests/ToUnicodeTests.cs
@@ -15,14 +15,15 @@ namespace WPFKeyboard.KBD.Tests
         [Test]
         public void Can_get_characters_from_mod_bits() 
         {
-            var handle = InputLanguage.InstalledInputLanguages.Cast<InputLanguage>().First().Handle;
+            //var handle = InputLanguage.InstalledInputLanguages.Cast<InputLanguage>().First().Handle;
+            var handle = NativeMethods.GetKeyboardLayout(0);
             SimulateModiferKeys(false, false, VirtualKeyCode.SHIFT, VirtualKeyCode.SHIFT);
             var resut = KeyboardHelper.GetKeyNameFromVirtualKey(handle, WindowsInput.Native.VirtualKeyCode.VK_A, _modifierStateManager.Object.ModifierState, _modifierKeys, true);
         }
 
         public override InstalledKeyboardLayout GetKeyboardLayout()
         {
-            return KeyboardHelper.InstalledKeyboardLayouts["US"];
+            return KeyboardHelper.InstalledKeyboardLayouts[((NativeMethods.GetKeyboardLayout(0).ToInt32() >> 16) & 0xFFFF).ToString("x8")];
         }
     }
 }

--- a/WPFKeyboard/KeyboardHelper.cs
+++ b/WPFKeyboard/KeyboardHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using WindowsInput.Native;
 
@@ -36,7 +37,7 @@ namespace WPFKeyboard
             foreach (var locale in registry.GetSubKeyNames())
             {
                 var layout = BuildKeyboardLayout(locale);
-                InstalledKeyboardLayouts.Add(layout.LayoutText, layout);
+                InstalledKeyboardLayouts.Add(locale, layout);
             }
         }
 

--- a/WPFKeyboard/NativeMethods.cs
+++ b/WPFKeyboard/NativeMethods.cs
@@ -44,6 +44,9 @@ namespace WPFKeyboard
 
         #region Keyboard
 
+        [DllImport("user32.dll")]
+        static extern IntPtr GetKeyboardLayout(uint idThread);
+        
         [DllImport("user32.dll", CharSet = CharSet.Unicode,
             EntryPoint = "MapVirtualKeyExW", ExactSpelling = true)]
         public static extern uint MapVirtualKeyEx(


### PR DESCRIPTION
also changed dictionary for installed layouts from being name-layoutdetails to hexID-layoutdetails. this might not be optimal, but its more useful.

Alternatively to this:
```
((NativeMethods.GetKeyboardLayout(0).ToInt32() >> 16) & 0xFFFF).ToString("x8")
```
This could also be used:
```
System.Globalization.CultureInfo.CurrentCulture.KeyboardLayoutId.ToString("x8")
```
but I have gotten inconsistent results using that API call, so I would avoid using it.

This also worked reliably, but it takes up more space, so I opted for the first one. It is cleaner and probably easier to understand than the first one, so it might make more sense in another commit: (GetKeyboardLayoutName is a native method as well)
```
            StringBuilder locale = new StringBuilder(new string(' ', 256));
            string keyboardLanguage;
            GetKeyboardLayoutName(locale);
            keyboardLanguage = locale.ToString();
```