### PR TITLE
Dead keys

### DIFF
--- a/Headers/KLL.h
+++ b/Headers/KLL.h
@@ -17,6 +17,7 @@ public:
 	struct VK_STRUCT_KEY
 	{
 		bool IsLig;
+		bool IsDeadKey;
 		int Character;
 		std::vector<int> Ligs;
 	};

--- a/WindowsKeyboardLayout/KeyboardLayoutHelper.cpp
+++ b/WindowsKeyboardLayout/KeyboardLayoutHelper.cpp
@@ -46,7 +46,7 @@ WPFKeyboardNative::KeyboardLayout^ WPFKeyboardNative::KeyboardLayoutHelper::GetL
 				{
 					ligs[z] = vk->Characters[y].Ligs.at(z);
 				}
-				characters[y] = gcnew VirtualKeyCharacter(vk->Characters[y].IsLig, vk->Characters[y].Character, ligs);
+				characters[y] = gcnew VirtualKeyCharacter(vk->Characters[y].IsLig, vk->Characters[y].IsDeadKey, vk->Characters[y].Character, ligs);
 			}
 
 			layout->VirtualKeys->Add(gcnew VirtualKey(vk->VirtualKey, vk->Attributes, characters));

--- a/WindowsKeyboardLayout/VirtualKey.cpp
+++ b/WindowsKeyboardLayout/VirtualKey.cpp
@@ -1,9 +1,10 @@
 #include "stdafx.h"
 #include "VirtualKey.h"
 
-WPFKeyboardNative::VirtualKeyCharacter::VirtualKeyCharacter(bool isLig, int character, array<int>^ ligs)
+WPFKeyboardNative::VirtualKeyCharacter::VirtualKeyCharacter(bool isLig, bool isDeadKey, int character, array<int>^ ligs)
 {
 	_isLig = isLig;
+	_isDeadKey = isDeadKey;
 	_character = character;
 	_ligs = ligs;
 }
@@ -11,6 +12,11 @@ WPFKeyboardNative::VirtualKeyCharacter::VirtualKeyCharacter(bool isLig, int char
 bool WPFKeyboardNative::VirtualKeyCharacter::IsLig::get()
 {
 	return _isLig;
+}
+
+bool WPFKeyboardNative::VirtualKeyCharacter::IsDeadKey::get()
+{
+	return _isDeadKey;
 }
 
 int WPFKeyboardNative::VirtualKeyCharacter::Character::get()

--- a/WindowsKeyboardLayout/VirtualKey.h
+++ b/WindowsKeyboardLayout/VirtualKey.h
@@ -5,12 +5,14 @@ namespace WPFKeyboardNative
 	public ref class VirtualKeyCharacter
 	{
 	private:
+		bool _isDeadKey;
 		bool _isLig;
 		int _character;
 		array<int>^ _ligs;
 	public:
-		VirtualKeyCharacter(bool isLog, int character, array<int>^ ligs);
+		VirtualKeyCharacter(bool isLog, bool isDeadKey, int character, array<int>^ ligs);
 		property bool IsLig { bool get(); }
+		property bool IsDeadKey { bool get(); }
 		property int Character { int get(); }
 		property array<int>^ Ligs { array<int>^ get(); }
 	};


### PR DESCRIPTION
Retrieves the character for a dead key, and marks the character as a Dead Key.

The information regarding DeadKeys can be found here;

https://github.com/pauldotknopf/WPFKeyboard/blob/3a36008df21fafc8537011c9befa27b1c0ef68fd/Headers/kbd64.h#L344-L369

I included support for both 32bit and 64bit OS, however I've only tested on a 64Bit OS, so I can't verify that the 32bit code is functional.

I've also not updated the pre-built `WindowsKeyboardLayout.dll` files in the repo, as I didn't have the older toolkits/SDKs (I had upgraded locally), so you will need to commit updated builds if you merge this PR